### PR TITLE
Use axis tags from empty arrays

### DIFF
--- a/arraycontext/__init__.py
+++ b/arraycontext/__init__.py
@@ -61,7 +61,7 @@ from .container.traversal import (
         thaw, freeze,
         flatten, unflatten, flat_size_and_dtype,
         from_numpy, to_numpy,
-        outer)
+        outer, with_array_context)
 
 from .impl.pyopencl import PyOpenCLArrayContext
 from .impl.pytato import (PytatoPyOpenCLArrayContext,
@@ -101,7 +101,7 @@ __all__ = (
         "rec_map_reduce_array_container", "rec_multimap_reduce_array_container",
         "thaw", "freeze",
         "flatten", "unflatten", "flat_size_and_dtype",
-        "from_numpy", "to_numpy",
+        "from_numpy", "to_numpy", "with_array_context",
         "outer",
 
         "PyOpenCLArrayContext", "PytatoPyOpenCLArrayContext",

--- a/arraycontext/container/traversal.py
+++ b/arraycontext/container/traversal.py
@@ -71,7 +71,8 @@ import numpy as np
 from arraycontext.context import ArrayContext, Array, _ScalarLike
 from arraycontext.container import (
         ArrayT, ContainerT, ArrayOrContainerT, NotAnArrayContainerError,
-        serialize_container, deserialize_container)
+        serialize_container, deserialize_container,
+        get_container_context_recursively_opt)
 
 
 # {{{ array container traversal helpers
@@ -533,20 +534,22 @@ def freeze(
 
     See :meth:`ArrayContext.thaw`.
     """
-    try:
-        iterable = serialize_container(ary)
-    except NotAnArrayContainerError:
-        if actx is None:
-            raise TypeError(
-                    f"cannot freeze arrays of type {type(ary).__name__} "
-                    "when actx is not supplied. Try calling actx.freeze "
-                    "directly or supplying an array context")
-        else:
-            return actx.freeze(ary)
+    if actx is None:
+        actx = get_container_context_recursively_opt(ary)
     else:
-        return deserialize_container(ary, [
-            (key, freeze(subary, actx=actx)) for key, subary in iterable
-            ])
+        if __debug__:
+            rec_actx = get_container_context_recursively_opt(ary)
+            if (rec_actx is not None) and (rec_actx is not actx):
+                raise ValueError("Supplied array context does not agree with"
+                                 " the one obtained by traversing 'ary'.")
+
+    if actx is None:
+        raise TypeError(
+                f"cannot freeze arrays of type {type(ary).__name__} "
+                "when actx is not supplied. Try calling actx.freeze "
+                "directly or supplying an array context")
+
+    return actx.freeze(ary)
 
 
 @singledispatch
@@ -570,14 +573,35 @@ def thaw(ary: ArrayOrContainerT, actx: ArrayContext) -> ArrayOrContainerT:
         in :mod:`meshmode`. This was necessary because
         :func:`~functools.singledispatch` only dispatches on the first argument.
     """
+    if __debug__:
+        rec_actx = get_container_context_recursively_opt(ary)
+        if rec_actx is not None:
+            raise ValueError("cannot thaw a container that already has an array"
+                             " context.")
+
+    return actx.thaw(ary)
+
+# }}}
+
+
+# {{{ with_array_context
+
+@singledispatch
+def with_array_context(ary: ArrayOrContainerT,
+                       actx: Optional[ArrayContext]) -> ArrayOrContainerT:
+    """
+    Recursively associates *actx* to all the components of *ary*.
+
+    Array container types may use :func:`functools.singledispatch` ``.register``
+    to register additional implementations.
+    """
     try:
         iterable = serialize_container(ary)
     except NotAnArrayContainerError:
-        return actx.thaw(ary)
+        return ary
     else:
-        return deserialize_container(ary, [
-            (key, thaw(subary, actx)) for key, subary in iterable
-            ])
+        return deserialize_container(ary, [(key, with_array_context(subary, actx))
+                                           for key, subary in iterable])
 
 # }}}
 
@@ -842,7 +866,10 @@ def to_numpy(ary: ArrayOrContainerT, actx: ArrayContext) -> Any:
                     f"array of type '{type(subary).__name__}' not in "
                     f"supported types {actx.array_types}")
 
-    return rec_map_array_container(_to_numpy_with_check, ary)
+    return rec_map_array_container(_to_numpy_with_check,
+                                   # do a freeze first, if 'actx' supports
+                                   # container-wide freezes
+                                   thaw(freeze(ary, actx), actx))
 
 # }}}
 

--- a/arraycontext/impl/jax/__init__.py
+++ b/arraycontext/impl/jax/__init__.py
@@ -32,6 +32,8 @@ import numpy as np
 from typing import Union, Callable, Any
 from pytools.tag import ToTagSetConvertible
 from arraycontext.context import ArrayContext, _ScalarLike
+from arraycontext.container.traversal import (rec_map_array_container,
+                                              with_array_context)
 
 
 class EagerJAXArrayContext(ArrayContext):
@@ -84,10 +86,22 @@ class EagerJAXArrayContext(ArrayContext):
                                   " operations using ArrayContext.np.")
 
     def freeze(self, array):
-        return array.block_until_ready()
+        from jax.numpy import DeviceArray
+
+        def _rec_freeze(ary):
+
+            if isinstance(ary, DeviceArray):
+                pass
+            else:
+                raise TypeError(f"{type(self).__name__}.thaw expects "
+                                f"`jax.DeviceArray` got {type(ary)}.")
+            return ary.block_until_ready()
+
+        return with_array_context(rec_map_array_container(_rec_freeze, array),
+                                  actx=None)
 
     def thaw(self, array):
-        return array
+        return with_array_context(array, actx=self)
 
     # }}}
 

--- a/arraycontext/impl/pytato/__init__.py
+++ b/arraycontext/impl/pytato/__init__.py
@@ -43,9 +43,10 @@ THE SOFTWARE.
 """
 
 from arraycontext.context import ArrayContext, _ScalarLike
-from arraycontext.container.traversal import rec_map_array_container
+from arraycontext.container.traversal import (rec_map_array_container,
+                                              with_array_context)
 import numpy as np
-from typing import Any, Callable, Union, TYPE_CHECKING, Tuple, Type
+from typing import Any, Callable, Union, TYPE_CHECKING, Tuple, Type, Dict
 from pytools.tag import ToTagSetConvertible
 import abc
 
@@ -210,45 +211,69 @@ class PytatoPyOpenCLArrayContext(_BasePytatoArrayContext):
         import pytato as pt
         import pyopencl.array as cla
         import loopy as lp
+
+        from arraycontext.container import ArrayT
+        from arraycontext.container.traversal import rec_keyed_map_array_container
         from arraycontext.impl.pytato.utils import (_normalize_pt_expr,
                                                     get_cl_axes_from_pt_axes)
         from arraycontext.impl.pyopencl.taggable_cl_array import (to_tagged_cl_array,
                                                                   TaggableCLArray)
+        from arraycontext.impl.pytato.compile import _ary_container_key_stringifier
 
-        if isinstance(array, TaggableCLArray):
-            return array.with_queue(None)
-        if isinstance(array, cla.Array):
-            from warnings import warn
-            warn("Freezing pyopencl.array.Array will be deprecated in 2023."
-                 " Use `to_tagged_cl_array` to convert the array to"
-                 " TaggableCLArray", DeprecationWarning, stacklevel=2)
-            return to_tagged_cl_array(array.with_queue(None),
-                                      axes=None,
-                                      tags=frozenset())
-        if isinstance(array, pt.DataWrapper):
-            # trivial freeze.
-            return to_tagged_cl_array(array.data.with_queue(None),
-                                      axes=get_cl_axes_from_pt_axes(array.axes),
-                                      tags=array.tags)
-        if not isinstance(array, pt.Array):
-            raise TypeError(f"{type(self).__name__}.freeze invoked "
-                            f"with non-pytato array of type '{type(array)}'")
+        array_as_dict: Dict[str, Union[cla.Array, TaggableCLArray,
+                                       pt.Array]] = {}
+        key_to_frozen_subary: Dict[str, TaggableCLArray] = {}
+        key_to_pt_arrays: Dict[str, pt.Array] = {}
 
-        # {{{ early exit for 0-sized arrays
+        def _record_leaf_ary_in_dict(key: Tuple[Any, ...],
+                                     ary: ArrayT):
+            key_str = "_actx" + _ary_container_key_stringifier(key)
+            array_as_dict[key_str] = ary
+            return ary
 
-        if array.size == 0:
-            return to_tagged_cl_array(
-                cla.empty(self.queue.context,
-                          shape=array.shape,
-                          dtype=array.dtype,
-                          allocator=self.allocator),
-                get_cl_axes_from_pt_axes(array.axes),
-                array.tags)
+        rec_keyed_map_array_container(_record_leaf_ary_in_dict, array)
+
+        # {{{ remove any non pytato arrays from array_as_dict
+
+        for key, subary in array_as_dict.items():
+            if isinstance(subary, TaggableCLArray):
+                key_to_frozen_subary[key] = subary.with_queue(None)
+            elif isinstance(subary, cla.Array):
+                from warnings import warn
+                warn("Freezing pyopencl.array.Array will be deprecated in 2023."
+                     " Use `to_tagged_cl_array` to convert the array to"
+                     " TaggableCLArray", DeprecationWarning, stacklevel=2)
+                key_to_frozen_subary[key] = to_tagged_cl_array(
+                    subary.with_queue(None),
+                    axes=None,
+                    tags=frozenset())
+            elif isinstance(subary, pt.DataWrapper):
+                # trivial freeze.
+                key_to_frozen_subary[key] = to_tagged_cl_array(
+                    subary.data,
+                    axes=get_cl_axes_from_pt_axes(subary.axes),
+                    tags=subary.tags)
+            else:
+                if not isinstance(subary, pt.Array):
+                    raise TypeError(f"{type(self).__name__}.freeze invoked with "
+                                    f"non-pytato array of type '{type(subary)}'")
+
+                if subary.size == 0:
+                    # early exit for 0-sized arrays
+                    key_to_frozen_subary[key] = to_tagged_cl_array(
+                        cla.empty(self.queue.context,
+                                  shape=subary.shape,
+                                  dtype=subary.dtype,
+                                  allocator=self.allocator),
+                        get_cl_axes_from_pt_axes(subary.axes),
+                        subary.tags)
+                else:
+                    key_to_pt_arrays[key] = subary
 
         # }}}
 
         pt_dict_of_named_arrays = pt.make_dict_of_named_arrays(
-                {"_actx_out": array})
+            key_to_pt_arrays)
 
         normalized_expr, bound_arguments = _normalize_pt_expr(
                 pt_dict_of_named_arrays)
@@ -268,16 +293,31 @@ class PytatoPyOpenCLArrayContext(_BasePytatoArrayContext):
                                        cl_device=self.queue.device)
             pt_prg = pt_prg.with_transformed_program(self.transform_loopy_program)
             self._freeze_prg_cache[normalized_expr] = pt_prg
+        else:
+            transformed_dag = self._dag_transform_cache[normalized_expr]
 
         assert len(pt_prg.bound_arguments) == 0
         evt, out_dict = pt_prg(self.queue, **bound_arguments)
         evt.wait()
+        assert len(set(out_dict) & set(key_to_frozen_subary)) == 0
 
-        return to_tagged_cl_array(
-            out_dict["_actx_out"].with_queue(None),
-            get_cl_axes_from_pt_axes(
-                self._dag_transform_cache[normalized_expr]["_actx_out"].expr.axes),
-            array.tags)
+        key_to_frozen_subary = {
+            **key_to_frozen_subary,
+            **{k: to_tagged_cl_array(v.with_queue(None),
+                                     get_cl_axes_from_pt_axes(transformed_dag[k]
+                                                              .expr
+                                                              .axes),
+                                     transformed_dag[k].expr.tags)
+               for k, v in out_dict.items()}
+        }
+
+        def _to_frozen(key: Tuple[Any, ...], ary: ArrayT):
+            key_str = "_actx" + _ary_container_key_stringifier(key)
+            return key_to_frozen_subary[key_str]
+
+        return with_array_context(rec_keyed_map_array_container(_to_frozen,
+                                                                array),
+                                  actx=None)
 
     def thaw(self, array):
         import pytato as pt
@@ -286,18 +326,22 @@ class PytatoPyOpenCLArrayContext(_BasePytatoArrayContext):
                                                                   to_tagged_cl_array)
         import pyopencl.array as cl_array
 
-        if isinstance(array, TaggableCLArray):
-            pass
-        elif isinstance(array, cl_array.Array):
-            array = to_tagged_cl_array(array, axes=None, tags=frozenset())
-        else:
-            raise TypeError("PytatoPyOpenCLArrayContext.thaw expects "
-                            "'TaggableCLArray' or 'cl.array.Array' got "
-                            f"{type(array)}.")
+        def _rec_thaw(ary):
 
-        return pt.make_data_wrapper(array.with_queue(self.queue),
-                                    axes=get_pt_axes_from_cl_axes(array.axes),
-                                    tags=array.tags)
+            if isinstance(ary, TaggableCLArray):
+                pass
+            elif isinstance(ary, cl_array.Array):
+                ary = to_tagged_cl_array(ary, axes=None, tags=frozenset())
+            else:
+                raise TypeError("PytatoPyOpenCLArrayContext.thaw expects "
+                                "'TaggableCLArray' or 'cl.array.Array' got "
+                                f"{type(ary)}.")
+            return pt.make_data_wrapper(ary.with_queue(self.queue),
+                                        axes=get_pt_axes_from_cl_axes(ary.axes),
+                                        tags=ary.tags)
+
+        return with_array_context(rec_map_array_container(_rec_thaw, array),
+                                  actx=self)
 
     # }}}
 
@@ -400,18 +444,46 @@ class PytatoJAXArrayContext(_BasePytatoArrayContext):
         raise ValueError(f"{type(self)} does not support calling loopy.")
 
     def freeze(self, array):
+
         import pytato as pt
         from jax.numpy import DeviceArray
 
-        if isinstance(array, DeviceArray):
-            return array.block_until_ready()
-        if not isinstance(array, pt.Array):
-            raise TypeError(f"{type(self)}.freeze invoked with "
-                            f"non-pytato array of type '{type(array)}'")
-
+        from arraycontext.container import ArrayT
+        from arraycontext.container.traversal import rec_keyed_map_array_container
+        from arraycontext.impl.pytato.compile import _ary_container_key_stringifier
         from arraycontext.impl.pytato.utils import _normalize_pt_expr
+
+        array_as_dict: Dict[str, Union[DeviceArray, pt.Array]] = {}
+        key_to_frozen_subary: Dict[str, DeviceArray] = {}
+        key_to_pt_arrays: Dict[str, pt.Array] = {}
+
+        def _record_leaf_ary_in_dict(key: Tuple[Any, ...],
+                                     ary: ArrayT):
+            key_str = "_actx" + _ary_container_key_stringifier(key)
+            array_as_dict[key_str] = ary
+            return ary
+
+        rec_keyed_map_array_container(_record_leaf_ary_in_dict, array)
+
+        # {{{ remove any non pytato arrays from array_as_dict
+
+        for key, subary in array_as_dict.items():
+            if isinstance(subary, self.frozen_array_types):
+                key_to_frozen_subary[key] = subary.block_until_ready()
+            elif isinstance(subary, pt.DataWrapper):
+                # trivial freeze.
+                key_to_frozen_subary[key] = subary.data.block_until_ready()
+            else:
+                if not isinstance(subary, pt.Array):
+                    raise TypeError(f"{type(self).__name__}.freeze invoked with "
+                                    f"non-pytato array of type '{type(subary)}'")
+
+                key_to_pt_arrays[key] = subary
+
+        # }}}
+
         pt_dict_of_named_arrays = pt.make_dict_of_named_arrays(
-                {"_actx_out": array})
+            key_to_pt_arrays)
 
         normalized_expr, bound_arguments = _normalize_pt_expr(
                 pt_dict_of_named_arrays)
@@ -419,23 +491,50 @@ class PytatoJAXArrayContext(_BasePytatoArrayContext):
         try:
             pt_prg = self._freeze_prg_cache[normalized_expr]
         except KeyError:
-            pt_prg = pt.generate_jax(self.transform_dag(normalized_expr),
+            if normalized_expr in self._dag_transform_cache:
+                transformed_dag = self._dag_transform_cache[normalized_expr]
+            else:
+                transformed_dag = self.transform_dag(normalized_expr)
+                self._dag_transform_cache[normalized_expr] = transformed_dag
+
+            pt_prg = pt.generate_jax(transformed_dag,
                                      jit=True)
             self._freeze_prg_cache[normalized_expr] = pt_prg
+        else:
+            transformed_dag = self._dag_transform_cache[normalized_expr]
 
         assert len(pt_prg.bound_arguments) == 0
         out_dict = pt_prg(**bound_arguments)
+        assert len(set(out_dict) & set(key_to_frozen_subary)) == 0
 
-        return out_dict["_actx_out"].block_until_ready()
+        key_to_frozen_subary = {
+            **key_to_frozen_subary,
+            **{k: v.block_until_ready()
+               for k, v in out_dict.items()}
+        }
+
+        def _to_frozen(key: Tuple[Any, ...], ary: ArrayT):
+            key_str = "_actx" + _ary_container_key_stringifier(key)
+            return key_to_frozen_subary[key_str]
+
+        return with_array_context(rec_keyed_map_array_container(_to_frozen,
+                                                                array),
+                                  actx=None)
 
     def thaw(self, array):
         import pytato as pt
 
-        if not isinstance(array, self.frozen_array_types):
-            raise TypeError(f"{type(self)}.thaw expects jax device arrays, got "
-                            f"{type(array)}")
+        def _rec_thaw(ary):
 
-        return pt.make_data_wrapper(array)
+            if isinstance(ary, self.frozen_array_types):
+                pass
+            else:
+                raise TypeError(f"{type(self).__name__}.thaw expects "
+                                f"`jax.DeviceArray` got {type(ary)}.")
+            return pt.make_data_wrapper(ary)
+
+        return with_array_context(rec_map_array_container(_rec_thaw, array),
+                                  actx=self)
 
     def compile(self, f: Callable[..., Any]) -> Callable[..., Any]:
         from .compile import LazilyJAXCompilingFunctionCaller

--- a/arraycontext/impl/pytato/__init__.py
+++ b/arraycontext/impl/pytato/__init__.py
@@ -258,17 +258,7 @@ class PytatoPyOpenCLArrayContext(_BasePytatoArrayContext):
                     raise TypeError(f"{type(self).__name__}.freeze invoked with "
                                     f"non-pytato array of type '{type(subary)}'")
 
-                if subary.size == 0:
-                    # early exit for 0-sized arrays
-                    key_to_frozen_subary[key] = to_tagged_cl_array(
-                        cla.empty(self.queue.context,
-                                  shape=subary.shape,
-                                  dtype=subary.dtype,
-                                  allocator=self.allocator),
-                        get_cl_axes_from_pt_axes(subary.axes),
-                        subary.tags)
-                else:
-                    key_to_pt_arrays[key] = subary
+                key_to_pt_arrays[key] = subary
 
         # }}}
 

--- a/arraycontext/impl/pytato/compile.py
+++ b/arraycontext/impl/pytato/compile.py
@@ -46,7 +46,7 @@ import pytato as pt
 import itertools
 from pytools.tag import Tag
 
-from pytools import ProcessLogger
+from pytools import ProcessLogger, memoize
 
 import logging
 logger = logging.getLogger(__name__)
@@ -90,6 +90,7 @@ class LeafArrayDescriptor(AbstractInputDescriptor):
 # }}}
 
 
+@memoize
 def _ary_container_key_stringifier(keys: Tuple[Any, ...]) -> str:
     """
     Helper for :meth:`BaseLazilyCompilingFunctionCaller.__call__`. Stringifies an

--- a/test/test_arraycontext.py
+++ b/test/test_arraycontext.py
@@ -32,7 +32,7 @@ from arraycontext import (
         ArrayContext,
         dataclass_array_container, with_container_arithmetic,
         serialize_container, deserialize_container,
-        freeze, thaw,
+        freeze, thaw, with_array_context,
         FirstAxisIsElementsTag,
         PyOpenCLArrayContext,
         PytatoPyOpenCLArrayContext,
@@ -188,22 +188,9 @@ def _deserialize_dof_container(
                 for i, (stream_i, v) in enumerate(iterable)))
 
 
-@freeze.register(DOFArray)
-def _freeze_dofarray(ary, actx=None):
-    assert actx is None
-    return type(ary)(
-        None,
-        tuple(ary.array_context.freeze(subary) for subary in ary.data))
-
-
-@thaw.register(DOFArray)
-def _thaw_dofarray(ary, actx):
-    if ary.array_context is not None:
-        raise ValueError("cannot thaw DOFArray that already has an array context")
-
-    return type(ary)(
-        actx,
-        tuple(actx.thaw(subary) for subary in ary.data))
+@with_array_context.register(DOFArray)
+def _with_actx_dofarray(ary, actx):
+    return type(ary)(actx, ary.data)
 
 # }}}
 
@@ -1198,6 +1185,11 @@ class Velocity2D:
     u: ArrayContainer
     v: ArrayContainer
     array_context: ArrayContext
+
+
+@with_array_context.register(Velocity2D)
+def _with_actx_velocity_2d(ary, actx):
+    return type(ary)(ary.u, ary.v, actx)
 
 
 def scale_and_orthogonalize(alpha, vel):


### PR DESCRIPTION
Seems it's necessary to retain the axis tags for empty arrays; I get unification errors without this change.

(Not very familiar with this part of the code, so there's a good chance I broke something else in the process of trying to fix this... be warned. 🙂 )

cc @inducer